### PR TITLE
Switch from hard to soft links for webapp deployment

### DIFF
--- a/tasks/jenkins.yml
+++ b/tasks/jenkins.yml
@@ -8,5 +8,5 @@
   service: name=jenkins state=stopped enabled=no
 
 - name: "Set link to deploy Jenkins to {{ jboss.home }}/standalone/deployements/"
-  file: state=hard src=/usr/lib/jenkins/jenkins.war dest={{ jboss.home }}/standalone/deployments/jenkins.war owner=jboss group=jboss
-  when: jboss is defined 
+  file: state=link src=/usr/lib/jenkins/jenkins.war dest={{ jboss.home }}/standalone/deployments/jenkins.war owner=jboss group=jboss
+  when: jboss is defined

--- a/tasks/mjolnir.yml
+++ b/tasks/mjolnir.yml
@@ -2,4 +2,4 @@
   yum: name=mjolnir update_cache={{ yum.update_cache }} state=installed
 
 - name: "Deploy Mjolnir"
-  file: state=hard src=/usr/share/mjolnir/mjolnir.war dest={{ jboss.home }}/standalone/deployments/mjolnir.war owner=jboss group=jboss 
+  file: state=link src=/usr/share/mjolnir/mjolnir.war dest={{ jboss.home }}/standalone/deployments/mjolnir.war owner=jboss group=jboss

--- a/tasks/prbz-overview.yml
+++ b/tasks/prbz-overview.yml
@@ -5,7 +5,7 @@
   file: state=directory path=/usr/share/prbz-overview/ owner=jboss group=jboss
 
 - name: "Checks prbz-overview is deployed"
-  file: state=hard src=/usr/share/prbz-overview/prbz-overview.war dest={{ jboss.home }}/standalone/deployments/prbz-overview.war owner=jboss group=jboss 
+  file: state=link src=/usr/share/prbz-overview/prbz-overview.war dest={{ jboss.home }}/standalone/deployments/prbz-overview.war owner=jboss group=jboss
 
 - name: "Checks prbz-overview folder exists"
   file: name=/home/jboss/prbz-overview state=directory owner=jboss group=jboss


### PR DESCRIPTION
If this PR is approve, the following changes will need to be done on Thunder:

```
# rm /opt/rh/eap7/root/usr/share/wildfly/standalone/deployments/jenkins.war ; ln -s /usr/lib/jenkins/jenkins.war /opt/rh/eap7/root/usr/share/wildfly/standalone/deployments/jenkins.war

# rm /opt/rh/eap7/root/usr/share/wildfly/standalone/deployments/mjolnir.war ; ln -s /usr/share/mjolnir/mjolnir.war  /opt/rh/eap7/root/usr/share/wildfly/standalone/deployments/mjolnir.war 

# rm /opt/rh/eap7/root/usr/share/wildfly/standalone/deployments/prbz-overview.war; ln -s /usr/share/prbz-overview/prbz-overview.war
```

JBoss EAP should pick up this change automatically - and the redeployments will be log in its logfile:

`# tail -f /var/log/jboss-eap/console.log`

(And update the [documentation](https://mojo.redhat.com/docs/DOC-1095681) which still mentions hardlink)