### PR TITLE
Add monit check to detect 'zombie' jbossas instances

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -102,6 +102,7 @@
     custom_monitoring_scripts:
       - { check_name: 'docker-check', script_name: 'check-docker-container.sh', timeout: 5000 }
       - { check_name: 'eap7-check', script_name: 'check-eap7.sh', timeout: 5000 }
+      - { check_name: 'dead-jbossas', script_name: 'dead-jbossas', timeout: 5000 }
     scripts_home: { path: '/opt/jboss-set-ci-scripts/ops' }
     disabled_services_list:
       - { name: 'libvirtd', reason: 'came with RHEV install, finally not used' }


### PR DESCRIPTION
If accepted this changes requires to release and update [jboss-set-ci-scripts](https://github.com/rpelisse/hebe) 1.2.4, so that the scripts [dead-jbossas](https://github.com/rpelisse/hebe/commit/8dc2e4b9c0f4d56fc7ada24237b585e85c9d3cbf) is available.

Note that this change already lives on Thunder (the check is available), but it is not tracked by this project, and the script lives (untracked) in /root.

Also note that this PR depends on PR https://github.com/jboss-set/zeus/pull/4