### PR TITLE
remove .sh extension to match upcoming changes in jboss-set-ci-scripts

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -100,8 +100,8 @@
     docker: { suspiciously_long_running_time: '86395' }
     jboss: { bind_addr: "{{ ansible_nodename }}", port_shift: '400', home: '/opt/rh/eap7/root/usr/share/wildfly', jvm_memory: '2048m', package_name: 'eap7-wildfly', config: 'thunder.xml' }
     custom_monitoring_scripts:
-      - { check_name: 'docker-check', script_name: 'check-docker-container.sh', timeout: 5000 }
-      - { check_name: 'eap7-check', script_name: 'check-eap7.sh', timeout: 5000 }
+      - { check_name: 'docker-check', script_name: 'check-docker-container', timeout: 5000 }
+      - { check_name: 'eap7-check', script_name: 'check-eap7', timeout: 5000 }
       - { check_name: 'dead-jbossas', script_name: 'dead-jbossas', timeout: 5000 }
     scripts_home: { path: '/opt/jboss-set-ci-scripts/ops' }
     disabled_services_list:


### PR DESCRIPTION
Just a clean up - some scripts have .sh extension, some don't - harmonizing to have no .sh everywhere (for all ops scrips because they are designed to be command line tools - like ls, cp, and so on...).

This depends on [jboss-set-ci-scripts](https://github.com/jboss-set/hebe/commit/af1a3d4fb6b0b99224ff539a85a4a0b09c99c745) (1.2.4) which must released and installed first, before applying those changes.