### PR TITLE
Remove checks on gitlab down

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -112,7 +112,6 @@
       - { name: 'nfs', reason: 'No reason to run NFS server, most likely leftover from RHEL setup' }
       - { name: 'rpcbind', reason: 'No reason to let the rpcbind sever running' }
       - { name: 'jbossas', reason: 'No longer used...' }
-      - { name: 'gitlab', reason: 'No reason to run it' }
     yum_repositories_list:
       - { name: 'jboss-eap7' }
       - { name: 'jboss-set'  }


### PR DESCRIPTION
The service script running gitlab is screwy and confuses Ansible, forcing to attempt to stop the service at each run. Thus I removed this checks. Gitlab has been disabled anyway, and unless somebody does fire it up, it won't come back on its own.