### PR TITLE
SET-23 Set up a HTTP proxy cache for Maven Central on Thunder

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -5,7 +5,7 @@
 # Caching static files for Jenkins
 proxy_cache_path /home/jboss/jenkins_workspace/.http_cache levels=1:2 keys_zone=jenkins_cache:10m max_size=10g;
 # Caching Maven central
-proxy_cache_path {{ maven_central_cache.directory }} levels=1:2 keys_zone={{ maven_central_cache.name }}:20m max_size={{ maven_central_cache.max_size }} use_temp_path=off inactive={{ maven_central_cache.inactive }};
+proxy_cache_path {{ maven_central_cache.directory }} levels=1:2 keys_zone={{ maven_central_cache.name }}:20m max_size={{ maven_central_cache.max_size }} inactive={{ maven_central_cache.inactive }};
 
 server {
     listen {{ ansible_default_ipv4.address }}:80;
@@ -80,7 +80,7 @@ server {
       proxy_cache_valid 200;
       add_header X-Cache-Status $upstream_cache_status;
       add_header Thunder-Cache True;
-      add_header Thunder-IP $remote_addr
+      add_header Thunder-IP $remote_addr;
       proxy_pass {{ maven_central_cache.url }};
    }
 


### PR DESCRIPTION
Fix typo in config (missing ;) and removed unsupported option on nginx's thunder