### PR TITLE
SET-23 - Set up a HTTP proxy cache for Maven Central on Thunder

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -115,7 +115,7 @@
     yum_repositories_list:
       - { name: 'jboss-eap7' }
       - { name: 'jboss-set'  }
-    maven_central_cache: { name: 'maven_central', directory: '/home/jboss/maven_central_cache', max_size: '20g', inactive: '90d', url: 'http://central.maven.org/maven2/' }
+        maven_central_cache: { name: 'maven_central', directory: '/home/jboss/maven_central_cache', max_size: '20g', inactive: '90d', expires: '90d', url: 'http://central.maven.org/maven2/' }
   tasks:
     - name: " ******* STAGE 0 *******"
       debug: msg=" >>> Check Ansible Set Up <<<"

--- a/hosts.yml
+++ b/hosts.yml
@@ -115,7 +115,11 @@
     yum_repositories_list:
       - { name: 'jboss-eap7' }
       - { name: 'jboss-set'  }
-        maven_central_cache: { name: 'maven_central', directory: '/home/jboss/maven_central_cache', max_size: '20g', inactive: '90d', expires: '90d', url: 'http://central.maven.org/maven2/' }
+    maven_http_cache_common_config: { name: 'maven_caches', directory: '/home/jboss/maven_central_cache', max_size: '20g', inactive: '90d', expires: '90d' }
+    maven_http_caches:
+      -  { name: 'maven_central', path: '/maven/', url: 'http://central.maven.org/maven2/' }
+      -  { name: 'jb-eap-7.1-rhel-7-maven-build', path: '/product/' , url: 'http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-eap-7.1-rhel-7-maven-build/latest/maven/' }
+      -  { name: 'jboss.org', path: '/jboss/', url: 'http://repository.jboss.org/nexus/content/groups/public/' }
   tasks:
     - name: " ******* STAGE 0 *******"
       debug: msg=" >>> Check Ansible Set Up <<<"

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,11 +1,17 @@
 - name: "Install nginx packages"
   yum: name=nginx update_cache={{ yum.update_cache }} state=installed
 
+- name: "Ensure folder for common configurations is created"
+  file: path=/etc/nginx/commons.d state=directory owner=root group=root mode=0775
+
+- name: "Ensure HTTP cache common config is created"
+  template: src=templates/nginx.maven.cache.conf.j2 dest=/etc/nginx/commons.d/nginx.maven.cache.conf owner=root group=root mode=0775
+
 - name: "Deploy nginx common proxy settings"
   template: src=templates/nginx.proxy.j2 dest=/etc/nginx/proxy.conf owner=root group=root mode=0644
 
 - name: "Ensure Maven Central cache directory is created"
-  file: path={{ maven_central_cache.directory }} state=directory owner=nginx group=nginx mode=0775
+  file: path={{ maven_http_cache_common_config.directory }} state=directory owner=nginx group=nginx mode=0775
 
 - name: "Deploy credentials for monit app"
   template: src=templates/nginx.monit.passwd.j2 dest=/etc/nginx/monit.passwd

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -5,7 +5,7 @@
 # Caching static files for Jenkins
 proxy_cache_path /home/jboss/jenkins_workspace/.http_cache levels=1:2 keys_zone=jenkins_cache:10m max_size=10g;
 # Caching Maven central
-proxy_cache_path {{ maven_central_cache.directory }} levels=1:2 keys_zone={{ maven_central_cache.name }}:20m max_size={{ maven_central_cache.max_size }} inactive={{ maven_central_cache.inactive }};
+proxy_cache_path {{ maven_http_cache_common_config.directory }} levels=1:2 keys_zone={{ maven_http_cache_common_config.name }}:20m max_size={{ maven_http_cache_common_config.max_size }} inactive={{ maven_http_cache_common_config.inactive }};
 
 server {
     listen {{ ansible_default_ipv4.address }}:80;
@@ -21,20 +21,13 @@ server {
       return 301 https://$host$request_uri;
     }
 
-    location /maven/ {
-      include /etc/nginx/common.d/nginx.maven.cache.conf;
-      proxy_pass http://central.maven.org/maven2/;
+    {% for maven_http_cache in maven_http_caches %}location {{ maven_http_cache.path }} {
+       include /etc/nginx/commons.d/nginx.maven.cache.conf;
+       proxy_pass {{ maven_http_cache.url }};
     }
+    {% endfor %}
 
-    location /product/ {
-      include /etc/nginx/common.d/nginx.maven.cache.conf;
-      proxy_pass http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-eap-7.1-rhel-7-maven-build/latest/maven/;
-    }
 
-    location /jboss/ {
-      include /etc/nginx/common.d/nginx.maven.cache.conf;
-      proxy_pass http://repository.jboss.org/nexus/content/groups/public/;
-    }
 }
 
 server {

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -22,16 +22,18 @@ server {
     }
 
     location /maven/ {
-      proxy_cache maven_central;
-      proxy_cache_min_uses 1;
-      proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-      proxy_cache_valid 200 $expires;
-      expires $expires;
-
-      add_header Thunder-Cache-Status $upstream_cache_status;
-      add_header Thunder-Cache True;
-      add_header Thunder-IP $remote_addr;
+      include /etc/nginx/common.d/nginx.maven.cache.conf;
       proxy_pass http://central.maven.org/maven2/;
+    }
+
+    location /product/ {
+      include /etc/nginx/common.d/nginx.maven.cache.conf;
+      proxy_pass http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-eap-7.1-rhel-7-maven-build/latest/maven/;
+    }
+
+    location /jboss/ {
+      include /etc/nginx/common.d/nginx.maven.cache.conf;
+      proxy_pass http://repository.jboss.org/nexus/content/groups/public/;
     }
 }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -11,6 +11,11 @@ server {
     listen {{ ansible_default_ipv4.address }}:80;
     server_name {{ ansible_nodename }};
     ssl off;
+    log_format maven_cache '$remote_addr - $upstream_cache_status [$time_local]  '
+                    '"$request" $status $body_bytes_sent '
+                    '"$http_referer" "$http_user_agent"';
+
+    #access_log   /var/log/nginx/maven.cache.log maven_cache;
 
     location / {
       return 301 https://$host$request_uri;
@@ -20,8 +25,10 @@ server {
       proxy_cache maven_central;
       proxy_cache_min_uses 1;
       proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-      proxy_cache_valid 200;
-      add_header X-Cache-Status $upstream_cache_status;
+      proxy_cache_valid 200 $expires;
+      expires $expires;
+
+      add_header Thunder-Cache-Status $upstream_cache_status;
       add_header Thunder-Cache True;
       add_header Thunder-IP $remote_addr;
       proxy_pass http://central.maven.org/maven2/;

--- a/templates/nginx.maven.cache.conf.j2
+++ b/templates/nginx.maven.cache.conf.j2
@@ -1,8 +1,8 @@
  proxy_cache maven_central;
  proxy_cache_min_uses 1;
  proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
- proxy_cache_valid 200 $expires;
- expires $expires;
+ proxy_cache_valid 200 {{ maven_http_cache_common_config.expires }};
+ expires {{ maven_http_cache_common_config.expires }};
 
  add_header Thunder-Cache-Status $upstream_cache_status;
  add_header Thunder-Cache True;

--- a/templates/nginx.maven.cache.conf.j2
+++ b/templates/nginx.maven.cache.conf.j2
@@ -1,0 +1,12 @@
+ proxy_cache maven_central;
+ proxy_cache_min_uses 1;
+ proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+ proxy_cache_valid 200 $expires;
+ expires $expires;
+
+ add_header Thunder-Cache-Status $upstream_cache_status;
+ add_header Thunder-Cache True;
+ add_header Thunder-IP $remote_addr;
+
+ proxy_ignore_headers Cache-Control Expires X-Accel-Expires Set-Cookie;
+ add_header Cache-Control public;


### PR DESCRIPTION
Follow up work on the deployment of a HTTP cache on Thunder. As it turns out we need to cache several different repositories (maven central, jboss.org, but also some product specific repos), this PR does some cleanup and much needed generic handling.