### PR TITLE
SET-32 - Makes monit checks that 'sudoers' user all belongs to the appropriate 'jboss-set' (local) group

### DIFF
--- a/files/sudo-group-check.sh
+++ b/files/sudo-group-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+status=0
+for user in $(ls /etc/sudoers.d/ -1)
+do 
+   if [ "${user}" != "50_vdsm" ]; then
+     id "${user}" | grep -e '1000(jboss-set)' 2>&1 > /dev/null
+     if [ "${?}" -ne 0 ]; then
+       echo "${user} does not belong to the jboss-set group, any sudo command will fail"
+       status=1
+     fi
+  fi
+done
+exit "${status}"

--- a/hosts.yml
+++ b/hosts.yml
@@ -104,6 +104,7 @@
       - { check_name: 'docker-check', script_name: 'check-docker-container', timeout: 5000 }
       - { check_name: 'eap7-check', script_name: 'check-eap7', timeout: 5000 }
       - { check_name: 'dead-jbossas', script_name: 'dead-jbossas', timeout: 5000 }
+      - { check_name: 'sudo-group-check', script_name: 'sudo-group-check', timeout: 5000 }
     scripts_home: { path: '/opt/jboss-set-ci-scripts/ops' }
     disabled_services_list:
       - { name: 'libvirtd', reason: 'came with RHEV install, finally not used' }

--- a/tasks/monit.yml
+++ b/tasks/monit.yml
@@ -35,6 +35,11 @@
     - { name: 'home', path: '/home', threshold: '90%' }
     - { name: 'docker-part', path: '/var/lib/docker', threshold: '90%' }
 
+  # other 'ops' should be moved out to Ansible, as most of the scripts in /opt/jboss-set-ci-scripts
+  # are more/less defunct
+- name: "Ensures custom scripts 'sudo-group-check' is deployed"
+  copy: src=files/sudo-check-group dest=/opt/jboss-set-ci-scripts/ owner=jboss group=jboss
+
 - name: "Set Monit checks based on custom scripts"
   template: src=templates/monit.script.j2 dest=/etc/monit.d/{{ item.check_name }} owner=root group=root
   with_items: "{{ custom_monitoring_scripts }}"


### PR DESCRIPTION
Issue: [SET-32](https://projects.engineering.redhat.com/browse/SET-32)

This change deploys a new script on Thunder that will check that each user defined in the sudoers.d folders belongs to the 'jboss-set' group, ensuring that user can indeed execute sudo command.