### PR TITLE
add download-ipv4.eng.brq.redhat.com to system monitored by Monit

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -107,6 +107,7 @@
       - { name: 'smtp.corp.redhat.com' }
       - { name: 'repository.jboss.org' }
       - { name: 'download.devel.redhat.com' }
+      - { name: 'download-ipv4.eng.brq.redhat.com' }
       - { name: 'issues.jboss.org' }
       - { name: 'bugzilla.redhat.com' }
       - { name: 'central.maven.org' }


### PR DESCRIPTION
yum update needs to fetch metadata from download-ipv4.eng.brq.redhat.com which is not resolved on thunder.
```

[wangc@thunder ~]$ sudo yum update prbz-overview
Loaded plugins: product-id, rhnplugin, security, subscription-manager, versionlock
This system is not registered to Red Hat Subscription Management. You can use subscription-manager to register.
This system is receiving updates from RHN Classic or RHN Satellite.
Setting up Update Process
http://download-ipv4.eng.brq.redhat.com/released/JBEAP-7/latest-released/JBEAP-7.0-RHEL-6/Server/x86_64/os/repodata/repomd.xml: [Errno 12] Timeout on http://download-ipv4.eng.brq.redhat.com/released/JBEAP-7/latest-released/JBEAP-7.0-RHEL-6/Server/x86_64/os/repodata/repomd.xml: (28, 'Operation too slow. Less than 1 bytes/sec transfered the last 30 seconds')
Trying other mirror.
Error: Cannot retrieve repository metadata (repomd.xml) for repository: jboss-eap7. Please verify its path and try again
```