### PR TITLE
adjust monit ping timeout

### DIFF
--- a/templates/monit.ping.j2
+++ b/templates/monit.ping.j2
@@ -1,2 +1,2 @@
 check host {{ item.name }} with address {{ item.name }}
-    if failed ping then alert
+    if failed ping with timeout 15 seconds then alert


### PR DESCRIPTION
I saw a massive ping test failure and success of github.com ping test on 29 March 2018. https://post-office.corp.redhat.com/mailman/private/jboss-set-ops/2018-March/date.html

Monit network ping test does not configure a timeout. This adjust it to 15 seconds as per

> If no reply arrive within TIMEOUT seconds, Monit reports an error. If at least one reply was received, the ping test is considered a success.

in https://mmonit.com/monit/documentation/monit.html