### PR TITLE
Add checks for remote HTTP services

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -100,7 +100,6 @@
       - { name: 'lo:10', filename: 'lo_10', ip_addr: 127.0.1.1,  netmask: 255.255.255.0, network: 127.0.0.0, broadcast: 127.255.255.255, onboot: 'yes' }
       - { name: 'lo:11', filename: 'lo_11', ip_addr: 127.0.1.2,  netmask: 255.255.255.0, network: 127.0.0.0, broadcast: 127.255.255.255, onboot: 'yes' }
     dnsnames:
-      - { name: 'github.com' }
       - { name: 'raw.githubusercontent.com' }
       - { name: 'kerberos.corp.redhat.com' }
       - { name: 'ldap.corp.redhat.com' }
@@ -140,6 +139,8 @@
       -  { name: 'jb-eap-7.1-rhel-7-maven-build', path: '/eap-7.1/' , url: 'http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-eap-7.1-rhel-7-maven-build/latest/maven/' }
       -  { name: 'jb-eap-7.0-rhel-7-maven-build', path: '/eap-7.0/' , url: 'http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-eap-7.0-rhel-7-maven-build/latest/maven/' }
       -  { name: 'jboss.org', path: '/jboss/', url: 'http://repository.jboss.org/nexus/content/groups/public/' }
+    remote_http_services:
+      -  { name: 'github', hostname: 'github.com', path: '/jboss-set' }
     logs_cleaning:
       -  { name: 'cleaning-eap-server-logs',  root_folder: '/opt/rh/eap7/root/usr/share/wildfly/standalone/log', nb_days_oldest: 31, filename_pattern: 'server*.log.20*'}
   tasks:

--- a/tasks/monit.yml
+++ b/tasks/monit.yml
@@ -60,5 +60,9 @@
   template: src=templates/monit.cache.includes.j2 dest=/etc/monit.conf.d/cache-{{ item.name }} owner=root group=root
   with_items: "{{ maven_http_caches }}"
 
+- name: "Monitor remote HTTP services"
+  template: src=templates/monit.cache.includes.j2 dest=/etc/monit.conf.d/cache-{{ item.name }} owner=root group=root
+  with_items: "{{ remote_http_services }}"
+
 - name: "Ensure Monit itself is running"
   service: name=monit enabled=yes state=started

--- a/templates/monit.remote.http.service.j2
+++ b/templates/monit.remote.http.service.j2
@@ -1,0 +1,2 @@
+if failed host {{ item.hostname or ansible_nodename }} port {{ item.port or '80' }}
+          protocol {{ item.protocol or 'HTTPS' }} request {{ item.path }} with timeout {{ item.timeout or '6' }} seconds then alert


### PR DESCRIPTION
- and removed github from the icmp checks

It seems that Github had disabled ICMP or simply that our infra had a hard time forwarding the request for a while, which lead to many false+ from monitoring. So I'm suggesting here to replace this checks (and maybe other) by a more high-level check using HTTP.

@soul2zimate @iweiss what do you think about it?