### PR TITLE
Fix for cleaning old EAP logs

### DIFF
--- a/templates/cron-cleaning-logs.j2
+++ b/templates/cron-cleaning-logs.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo -n '${{item.name }} - Cleaning logs file in {{ item.root_folder }} older than {{ item.nb_days_oldest }} matching pattern {{ item.filename_pattern }}.'
-find {{ item.root_folder }} -mindepth 1 -mtime +{{ item.nb_days_oldest }} -name '{{ item.filename_pattern }}' -delete
+find -L {{ item.root_folder }} -mindepth 1 -mtime +{{ item.nb_days_oldest }} -name '{{ item.filename_pattern }}' -delete
 echo 'Done.'


### PR DESCRIPTION
/opt/rh/eap7/root/usr/share/wildfly/standalone/log is actually a symlink so find refuses to follow it by default