### PR TITLE
Improve default value so it behaves the same for custom <---- 0_o

### DIFF
--- a/templates/harmonia-eap-build.j2
+++ b/templates/harmonia-eap-build.j2
@@ -5,9 +5,10 @@
 readonly HARMONIA_REPOSITORY=${HARMONIA_REPOSITORY:-'git@github.com:jboss-set/harmonia.git'}
 readonly HARMONIA_BRANCH=${HARMONIA_BRANCH:-'master'}
 readonly HARMONIA_FOLDER=${HARMONIA_FOLDER:-'harmonia'}
-readonly HARMONIA_BUILD_SCRIPT=${HARMONIA_BUILD_SCRIPT:-"${HARMONIA_FOLDER}/eap-job.sh"}
+readonly HARMONIA_BUILD_SCRIPT_NAME=${HARMONIA_BUILD_SCRIPT_NAME:-'eap-job.sh'}
+readonly HARMONIA_BUILD_SCRIPT=${HARMONIA_BUILD_SCRIPT:-"${HARMONIA_FOLDER}/${HARMONIA_BUILD_SCRIPT_NAME}"}
 
-readonly MAVEN_SETTINGS_XML=${MAVEN_SETTINGS_XML:-'/home/master/settings.xml'}
+readonly MAVEN_SETTINGS_XML=${MAVEN_SETTINGS_XML-'/home/master/settings.xml'}
 
 clean() {
   if [[ ! -z "${HARMONIA_FOLDER}" ]]; then


### PR DESCRIPTION
Allow to set custom job script in a way so harmonia behaves the same regardless if it is default value or custom.