### PR TITLE
Expose mjolnir dev instance

### DIFF
--- a/tasks/jboss-eap7.yml
+++ b/tasks/jboss-eap7.yml
@@ -57,3 +57,12 @@
           driver_name: "{{ mjolnir_ds.driver_name }}"
           user_name: "{{ mjolnir_ds.user_name }}"
           password: "{{ mjolnir_ds.password }}"
+        - name: "{{ mjolnir_dev_ds.name }}"
+          pool_name: "{{ mjolnir_dev_ds.pool_name }}"
+          enabled: true
+          use_java_context: "{{ mjolnir_dev_ds.use_java_context }}"
+          jndi_name: "{{ mjolnir_dev_ds.jndi_name }}"
+          connection_url: "{{ mjolnir_dev_ds.connection_url }}"
+          driver_name: "{{ mjolnir_dev_ds.driver_name }}"
+          user_name: "{{ mjolnir_dev_ds.user_name }}"
+          password: "{{ mjolnir_dev_ds.password }}"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -73,6 +73,12 @@ server {
       include /etc/nginx/proxy.conf;
     }
 
+    location /mjolnir-dev {
+      proxy_pass http://{{ ansible_nodename }}:8480 ;
+      proxy_redirect     http://{{ ansible_nodename }}:8480 https://{{ ansible_nodename }};
+      include /etc/nginx/proxy.conf;
+    }
+
     location /prbz-overview {
       proxy_pass http://{{ ansible_nodename }}:8480 ;
       proxy_redirect     http://{{ ansible_nodename }}:8480 https://{{ ansible_nodename }};


### PR DESCRIPTION
We need to expose development instance for mjolnir.

Incomplete: I don't know where to define the `mjolnir_dev_ds.*` properties for datasource. There are already equivalent properties for production instance...