### PR TITLE
[SET-226] Add option to rebuild JDK keystores when updating Thunder c…

### DIFF
--- a/tasks/java_certs.yml
+++ b/tasks/java_certs.yml
@@ -1,3 +1,15 @@
+- name: Remove SSL certificates in {{ jdk.name }}
+  when: rebuild_keystore|default(false)
+  java_cert:
+    cert_url: "{{ item.cert_url }}"
+    keystore_path: "{{ jdk.java_home }}/jre/lib/security/cacerts"
+    cert_alias: "{{ item.alias }}"
+    executable: "{{ jdk.java_home }}/bin/keytool"
+    keystore_pass: changeit
+    keystore_create: no
+    state: absent
+  with_items: "{{ certificate_list }}"
+
 - name: Import SSL certificates in {{ jdk.name }}
   java_cert:
     cert_url: "{{ item.cert_url }}"


### PR DESCRIPTION
…ertificate

Remove imported certificates if the playbook is run with -e '{"rebuild_keystore":true}'

@rpelisse WDYT? There's probably a better way to achieve that :)