### PR TITLE
jobs: add maven settings to be used for EAP 6.4 builds

### DIFF
--- a/roles/nginx/tasks/http_cache_setup.yml
+++ b/roles/nginx/tasks/http_cache_setup.yml
@@ -33,3 +33,11 @@
     group: jenkins
     mode: 0644
 
+- name: "Deploy settings-eap64.xml"
+  template:
+    src: templates/settings-eap64.xml.j2
+    dest: /opt/tools/settings-eap64.xml
+    owner: jenkins
+    group: jenkins
+    mode: 0644
+

--- a/roles/nginx/templates/settings-eap64.xml.j2
+++ b/roles/nginx/templates/settings-eap64.xml.j2
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <pluginGroups/>
+  <proxies/>
+  <servers/>
+  <mirrors/>
+  <profiles/>
+</settings>


### PR DESCRIPTION
@rpelisse @spyrkob would it be possible to add this empty maven settings for EAP 6.4 builds?

I'm fine with setting up caches in follow up PRs eventually, but I would first like to have something working, perks can come later...

My goal is to have the file available in the docker container which builds EAP. I'm not sure what else is necessary do achieve that, this is my best guess.