### PR TITLE
[SET-389] Add ability to support defining extra job parameters

### DIFF
--- a/roles/jobs/templates/job-template.yml.j2
+++ b/roles/jobs/templates/job-template.yml.j2
@@ -73,6 +73,18 @@
           name: PULL_REQUEST_PROCESSOR_HOME
           default: "{{ item.pr_processor_home }}"
 {% endif %}
+{% if item.params is defined %}
+{% for p in item.params %}
+      - {{ p.type }}:
+          name: {{ p.name }}
+          {% if p.default is defined %}
+          default: "{{ p.default | default('') }}"
+          {% endif %}
+          {% if p.description is defined %}
+          description: "{{ p.description | default('') }}"
+          {% endif %}
+{% endfor %}
+{% endif %}
     pipeline-scm:
       scm:
         - git:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-389

This PR tries to add support to defin extra job parameters in Zeus.