### PR TITLE
[SET-393] Code changes in hera, harmonia, cedalion triggers all jobs on Olympus

### DIFF
--- a/roles/jobs/defaults/main.yml
+++ b/roles/jobs/defaults/main.yml
@@ -15,3 +15,4 @@ jenkinsfile:
   git_repo: "{{ override_jenkinsfile_git_repo | default('https://github.com/jboss-set/cedalion') }}"
   path: "{{ override_jenkinsfile_path | default('Jenkinsfile') }}"
   eap_repo: "{{ git_repo_for_eap }}"
+  polling: "{{ override_jenkinsfile_polling | default('false') }}"

--- a/roles/jobs/templates/job-template.yml.j2
+++ b/roles/jobs/templates/job-template.yml.j2
@@ -91,6 +91,8 @@
             url: {{ jenkinsfile.git_repo }}
             branches:
               - origin/master
+            poll: {{ jenkinsfile.polling }}
+            changelog: {{ jenkinsfile.polling }}
       script-path: {{ item.jenkinsfile }}
       lightweight-checkout: true
     build-discarder:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-393

This PR tries to add additional variable: `jenkinsfile.polling` default to `false` so that changes in cedalion won't trigger job execution.

This may be controversial if it should or not trigger the job execution, so adding this variable make it flexible to update job on demand.