### PR TITLE
set up initial job for job-dsl

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -28,6 +28,8 @@ jenkins:
     port: "{{ override_ldap_port | default('636') }}"
     url: "{{ override_ldap_url | default('') }}"
     keystore: "{{ override_ldap_keystore }}"
+  root_ca:
+    url: "{{ override_root_ca_url | default('') }}"
   role:
     admin:
       name: "{{ override_jenkins_role_admin_name }}"

--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -45,7 +45,6 @@ jenkins:
       - eap-7.1.x
       - eap-7.2.x
       - eap-7.3.x
-      - eap-7.4.x
       - wildfly
       - xp-2.0.x
       - xp-3.0.x

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -49,18 +49,24 @@
     owner: "{{ jenkins.username }}"
     group: "{{ jenkins.groupname }}"
 
-- name: "Import SSL certificates from {{ jenkins.ldap.url }}"
+- name: "Download root CA"
+  get_url:
+    url: "{{ jenkins.root_ca.url }}"
+    dest: "{{ ares.home }}/hephaestus/Root-CA.crt"
+  when:
+    - jenkins.root_ca.url is defined
+
+- name: "Import Root CA"
   java_cert:
-    cert_url: "{{ jenkins.ldap.host }}"
-    cert_port: "{{ jenkins.ldap.port }}"
-    keystore_path: "{{ jenkins.ldap.keystore }}"
-    cert_alias: "{{ jenkins.ldap.host }}"
+    cert_path: "{{ ares.home }}/hephaestus/Root-CA.crt"
+    keystore_path: "{{ ares.home }}/hephaestus/cacerts"
+    cert_alias: "root-ca"
     executable: "{{ jenkins.default_jdk_home }}/bin/keytool"
     keystore_pass: changeit
     keystore_create: yes
     state: present
   when:
-    - jenkins.ldap is defined
+    - jenkins.root_ca.url is defined
 
 - set_fact:
      podman_services: "{{ podman_services }} + {{ jenkins.service }}"

--- a/roles/jenkins/templates/casc.yaml.j2
+++ b/roles/jenkins/templates/casc.yaml.j2
@@ -178,6 +178,11 @@ jenkins:
       - statBuilds:
           name: "Build statistics"
   viewsTabBar: "standard"
+
+security:
+  globalJobDslSecurityConfiguration:
+    useScriptSecurity: false
+
 tool:
 
 unclassified:
@@ -187,3 +192,8 @@ unclassified:
     replyToAddress: {{ mailer.replyTo }}
     smtpHost: {{ mailer.smtp.host }}
     smtpPort: {{ mailer.smtp.port }}
+
+jobs:
+  - url: "https://gitlab.cee.redhat.com/jboss-set/csb-jenkins-definition/-/raw/olympus/job-configurator.groovy"
+  - script: "queue('job-configurator')"
+

--- a/roles/jobs/templates/job-template.yml.j2
+++ b/roles/jobs/templates/job-template.yml.j2
@@ -95,7 +95,7 @@
               - origin/master
             poll: {{ jenkinsfile.polling }}
             changelog: {{ jenkinsfile.polling }}
-      script-path: {{ item.jenkinsfile }}
+      script-path: "pipelines/{{ item.jenkinsfile }}"
       lightweight-checkout: true
     build-discarder:
       days-to-keep: 30


### PR DESCRIPTION
Add initial job-dsl job to Jenkins casc, fix Jenkins trustore.

Requires https://github.com/jboss-set/ares/pull/5, https://gitlab.cee.redhat.com/jboss-set/zeus-vars/-/merge_requests/37 and https://github.com/jboss-set/cedalion/pull/13

Note the csb-jenkinks-definitions repo can be moved to github - I'm not sure which repository though. Should we restructure cedalion for it? Or is it better to go with separate repo?