### PR TITLE
Make postgres containers use volumes

### DIFF
--- a/roles/pgsql/defaults/main.yml
+++ b/roles/pgsql/defaults/main.yml
@@ -14,6 +14,7 @@ pgsql:
         url: 'https://raw.githubusercontent.com/jboss-set/mjolnir-archive-service/master/dbscripts/create.sql'
       load_data: 
         name: 'mjolnir-preprod_data.sql'
+      data_volume: /var/lib/pgsql-mjolnir-predprod
     component_upgrade:
       db_name: component-upgrade
       username: component-upgrade
@@ -22,6 +23,7 @@ pgsql:
       create_db: 
         name: 'component-upgrade-init.sql'
         url: 'https://raw.githubusercontent.com/TomasHofman/component-upgrade-logger/main/src/main/resources/init.sql'
+      data_volume: /var/lib/pgsql-component-upgrade-dev
 postgres_instances:
   services:
     - name: pgsql-mjolnir-predprod
@@ -33,6 +35,8 @@ postgres_instances:
       vars:
        - { name: 'POSTGRES_PASSWORD', value: "{{ pgsql.instances.mjolnir_preprod.password }}" }
        - { name: 'POSTGRES_USER', value: "{{ pgsql.instances.mjolnir_preprod.username }}" }
+      readwrite_volumes:
+       - { src: "{{ pgsql.instances.mjolnir_preprod.data_volume }}", dest: '/var/lib/postgresql/data' }
 
     - name: pgsql-component-upgrade-dev
       image: 'docker.io/library/postgres'
@@ -43,3 +47,5 @@ postgres_instances:
       vars:
        - { name: 'POSTGRES_PASSWORD', value: "{{ pgsql.instances.component_upgrade.password }}" }
        - { name: 'POSTGRES_USER', value: "{{ pgsql.instances.component_upgrade.username }}" }
+      readwrite_volumes:
+        - { src: "{{ pgsql.instances.component_upgrade.data_volume }}", dest: '/var/lib/postgresql/data' }

--- a/roles/pgsql/tasks/main.yml
+++ b/roles/pgsql/tasks/main.yml
@@ -18,6 +18,16 @@
     vars:
       package_name: python3-psycopg2
 
+  - name: "Creates data volume dirs for postgres containers"
+    file:
+      path: "{{ item }}"
+      state: directory
+      owner: jenkins
+      group: jenkins
+    loop:
+      - "{{ pgsql.instances.mjolnir_preprod.data_volume }}"
+      - "{{ pgsql.instances.component_upgrade.data_volume }}"
+
   - name: "Ensures {{ pgsql.scripts.home }} exists."
     file:
       path: "{{ pgsql.scripts.home }}"


### PR DESCRIPTION
The reason for this is to prevent the postgres containers from loosing schemas and data when they get recreated.

Please check the data volume paths (`/var/lib/pgsql-component-upgrade-dev`, `/var/lib/pgsql-mjolnir-predprod`), perhaps suggest better paths.

I'm not sure if this settings is correct permission wise.

@rpelisse @spyrkob 