### PR TITLE
SET-470 include will be removed in ansible version 2.16

### DIFF
--- a/roles/java_certs/tasks/main.yml
+++ b/roles/java_certs/tasks/main.yml
@@ -5,7 +5,7 @@
       - jdk_list is iterable
 
 - name: "Provisioning self-signed certificate to JDKs"
-  include: tasks/java_certs.yml
+  include_tasks: tasks/java_certs.yml
   loop: "{{ jdk_list }}"
   loop_control:
     loop_var: jdk


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-470

("include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in ansible version 2.16)