### PR TITLE
Add repositories to known hosts

### DIFF
--- a/roles/ssh/tasks/known_hosts.yml
+++ b/roles/ssh/tasks/known_hosts.yml
@@ -1,0 +1,16 @@
+---
+- ansible.builtin.assert:
+    that:
+      - known_host is defined
+    quiet: yes
+
+- name: get {{ known_host }} key
+  ansible.builtin.command: "ssh-keyscan -t ecdsa {{ known_host }} | grep ecdsa"
+  register: "host_key"
+  changed_when: false
+
+- name: add {{ known_host }} to known_hosts
+  ansible.builtin.known_hosts:
+    path: "{{ ssh_home }}/.ssh/known_hosts"
+    name: "{{ known_host }}"
+    key: "{{ host_key.stdout }}"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -10,3 +10,8 @@
   with_items: "{{ ssh.users }}"
   loop_control:
     loop_var: files
+
+- ansible.builtin.include_tasks: known_hosts.yml
+  with_items: "{{ ssh.known_hosts }}"
+  loop_control:
+    loop_var: known_host


### PR DESCRIPTION
The repositories need to be added to the known_hosts for Jenkins git host verification to work correctly

@rpelisse could you review please?