### PR TITLE
SET-541 Configure Jenkins to use OIDC auth if configured

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -24,6 +24,7 @@ jenkins_service_readonly_volumes:
   - { src: "/home/jenkins/.ssh", dest: '/var/jenkins_home/.ssh' }
   - { src: "/home/jenkins/.netrc", dest: '/var/jenkins_home/.netrc' }
   - { src: '/home/jenkins/.gitconfig', dest: '/var/jenkins_home/.gitconfig' }
+  - { src: '{{ ares.home }}/hephaestus/casc-prod.yaml', dest: '/casc.yaml' }
 jenkins_service_add_hosts:
   - { src: "{{ known_hosts.podman.name }}", ip: "{{ known_hosts.podman.ip }}" }
   - { src: "{{ known_hosts.server.name }}", ip: "{{ known_hosts.server.ip }}" }
@@ -36,6 +37,7 @@ jenkins_service_next_readonly_volumes:
   - { src: "/home/jenkins/.ssh", dest: '/var/jenkins_home/.ssh' }
   - { src: "/home/jenkins/.netrc", dest: '/var/jenkins_home/.netrc' }
   - { src: '/home/jenkins/.gitconfig', dest: '/var/jenkins_home/.gitconfig' }
+  - { src: '{{ ares.home }}/hephaestus/casc-staging.yaml', dest: '/casc.yaml' }
 jenkins_service_next_add_hosts:
   - { src: "{{ known_hosts.podman.name }}", ip: "{{ known_hosts.podman.ip }}" }
   - { src: "{{ known_hosts.server.name }}", ip: "{{ known_hosts.server.ip }}" }

--- a/roles/jenkins/tasks/main.yml
+++ b/roles/jenkins/tasks/main.yml
@@ -13,6 +13,8 @@
       - jenkins.tools is defined
       - jenkins.tools.home is defined
       - jenkins.tools.home != ""
+      - jenkins_sso.prod is defined
+      - jenkins_sso.staging is defined
     quiet: true
 
 - name: "Ensures data folder for Jenkins and Jenkins.next exists."
@@ -34,12 +36,23 @@
     owner: "{{ jenkins.username }}"
     group: "{{ jenkins.username }}"
 
-- name: "Deploy missing configuration file for Jenkins into {{ ares.home }}."
+- name: "Deploy prod Jenkins configuration file into {{ ares.home }}."
   ansible.builtin.template:
     src: templates/casc.yaml.j2
-    dest: "{{ ares.home }}/hephaestus/casc.yaml"
+    dest: "{{ ares.home }}/hephaestus/casc-prod.yaml"
     owner: "{{ ares.owner }}"
     group: "{{ ares.owner }}"
+  vars:
+    instance: jenkins_sso.prod
+
+- name: "Deploy staging Jenkins configuration file into {{ ares.home }}."
+  ansible.builtin.template:
+    src: templates/casc.yaml.j2
+    dest: "{{ ares.home }}/hephaestus/casc-staging.yaml"
+    owner: "{{ ares.owner }}"
+    group: "{{ ares.owner }}"
+  vars:
+    instance: jenkins_sso.staging
 
 - ansible.builtin.include_tasks: generate_keys.yml
   loop:

--- a/roles/jenkins/templates/casc.yaml.j2
+++ b/roles/jenkins/templates/casc.yaml.j2
@@ -82,7 +82,21 @@ jenkins:
 {% endfor %}{% endif %}
   numExecutors: {{ jenkins.executors.num }}
   securityRealm:
-{% if jenkins.ldap.url is defined and jenkins.ldap.url != ""  %}
+{% if instance.oidc.authorization_endpoint is defined and instance.oidc.authorization_endpoint|length %}
+    oic:
+      authorizationServerUrl: "{{ instance.oidc.authorization_endpoint }}"
+      tokenServerUrl: "{{ instance.oidc.token_endpoint }}"
+      userInfoServerUrl: "{{ instance.oidc.userinfo_endpoint }}"
+      automanualconfigure: "manual"
+      clientId: "{{ instance.oidc.client_id }}"
+      clientSecret: "{{ instance.oidc.client_secret }}"
+      disableSslVerification: false
+      groupsFieldName: "groups"
+      logoutFromOpenidProvider: false
+      scopes: "openid email"
+      tokenAuthMethod: "client_secret_post"
+      userNameField: "preferred_username"
+{% elif jenkins.ldap.url is defined and jenkins.ldap.url != ""  %}
     ldap:
       configurations:
       - groupSearchBase: "{{ jenkins.ldap.search.group.base }}"
@@ -145,7 +159,7 @@ tool:
 
 unclassified:
   location:
-    url: https://{{ ansible_nodename }}/jenkins
+    url: https://{{ instance.url }}/jenkins
   mailer:
     replyToAddress: {{ mailer.replyTo }}
     smtpHost: {{ mailer.smtp.host }}

--- a/roles/jenkins/vars/main.yml
+++ b/roles/jenkins/vars/main.yml
@@ -55,6 +55,8 @@ jenkins:
       readonly_volumes: "{{ jenkins_service_readonly_volumes }}"
       add_hosts: "{{ jenkins_service_add_hosts }}"
       ports_mapping: "{{ jenkins_service_ports_mapping }}"
+      vars:
+        - { name: 'JENKINS_OPTS', value: '--prefix=/jenkins'}
     - name: hephaestus.next
       ip: "{{ known_hosts.jenkins_next.ip }}"
       location: '/jenkins.next'
@@ -63,3 +65,5 @@ jenkins:
       readonly_volumes: "{{ jenkins_service_next_readonly_volumes }}"
       add_hosts: "{{ jenkins_service_next_add_hosts }}"
       ports_mapping: "{{ jenkins_service_next_ports_mapping }}"
+      vars:
+        - { name: 'JENKINS_OPTS', value: '--prefix=/jenkins.next' }

--- a/roles/podman/defaults/main.yml
+++ b/roles/podman/defaults/main.yml
@@ -16,7 +16,7 @@ podman:
       - { name: 'bashomatons', owner: 'jenkins', tag: 'bashomatons' }
       - { name: 'yarn-builder', owner: 'jenkins', tag: 'yarn-builder' }
       - { name: 'hephaestus', owner: 'root', tag: 'hephaestus' }
-      - { name: 'hephaestus.next', owner: 'root', tag: 'hephaestus.next' }
+      - { name: 'hephaestus', owner: 'root', tag: 'hephaestus.next' }
       - { name: 'ansible', owner: 'jenkins', tag: 'ansible' }
       - { name: 'molecule-runner', owner: 'jenkins', tag: 'molecule-runner' }
       - { name: 'molecule-slave', owner: 'jenkins', tag: 'molecule-slave' }

--- a/zeus.yml
+++ b/zeus.yml
@@ -12,6 +12,7 @@
       - vars/caches.yml
       - vars/java.yml
       - vars/java_certs.yml
+      - vars/jenkins_sso.yml
       - vars/jobs.yml
       - vars/component-alignment.yml
       - vars/mjolnir.yml


### PR DESCRIPTION
https://issues.redhat.com/browse/SET-541

Changes in the `casc.yaml` to configure OIDC authorization plugin.

Two files are going to be created now, `casc-prod.yaml` and `casc-staging.yaml`. Even if both instances use the same SSO server, they at least need to have different location URL configured, so that SSO server redirects back to correct instance.