### PR TITLE
SET-570 Automate updating CCI worker VMs in Gitlab.

### DIFF
--- a/cci_casc_edit.yml
+++ b/cci_casc_edit.yml
@@ -1,0 +1,51 @@
+---
+- name: Creating an empty file
+  file:
+    path: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+    state: directory
+
+- name: "Clone source code of personal forked {{ gitlab_repo }}"
+  git:
+    repo: "{{ forked_repo_link }}"
+    dest: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+    version: master
+    key_file: "{{ local_pubkey_path }}"
+
+- name: Add upstream
+  ansible.builtin.command: "git remote add upstream {{ upstream_repo_link }}"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+
+- name: Fetch upstream
+  ansible.builtin.command: "git fetch upstream"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+
+- name: Merge upstream
+  ansible.builtin.command: "git merge upstream/master"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+
+- name: Modify casc file with new images
+  ansible.builtin.command: "sed -i 's/{{ cci_os_old_snapshot_name }}/{{ cci_os_snapshot_name }}/' /home/{{ cci_os_username }}/{{ gitlab_repo }}/casc.yaml"
+
+- name: Add the new changes
+  ansible.builtin.command: "git add -A"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+
+- name: Create new Commmit
+  ansible.builtin.command: "git commit -m 'Edit casc.yaml with new image'"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+
+- name: create a new PR
+  ansible.builtin.command: "git push origin -f master"
+  args:
+    chdir: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"
+  register: results
+
+- name: "Delete {{ gitlab_repo }} from local."
+  ansible.builtin.file:
+    state: absent
+    path: "/home/{{ cci_os_username }}/{{ gitlab_repo }}"

--- a/cci_run.yml
+++ b/cci_run.yml
@@ -12,3 +12,6 @@
       with_items:
         - { url: "{{ cci_os_cluster_url_first }}", id: "{{ cci_os_project_id_first }}", network: "{{ cci_os_network_first }}", flavor: "{{ cci_os_flavor_first }}" }
         - { url: "{{ cci_os_cluster_url_second }}", id: "{{ cci_os_project_id_second }}", network: "{{ cci_os_network_second }}", flavor: "{{ cci_os_flavor_second }}" }
+
+    - name: Automate CCI VM using Ansible
+      include_tasks: cci_casc_edit.yml


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-570 

it can do the following ->

- Clone your forked [csb-jenkins-definition](https://gitlab.cee.redhat.com/jboss-set/csb-jenkins-definition) from gitlab.
- rebase it with changes with the upstream repo.
- Updated the newly formed image name 
- create the PR

Zeus vars PR: https://gitlab.cee.redhat.com/jboss-set/zeus-vars/-/merge_requests/80