### PR TITLE
SET-588 maven 3.6.3 is not found inside downloads.apache.org

### DIFF
--- a/molecule/java/vars.yml
+++ b/molecule/java/vars.yml
@@ -1,7 +1,7 @@
 ---
 # dummy variables for java role testing purpose.
 jdk_version: 17.0.1
-mvn_version: 3.6.3
+mvn_version: 3.9.3
 jdk_home_folder: /opt/java
 mvn_home_folder: /opt/java
 jdk_list:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-588
zeus-vars PR: https://gitlab.cee.redhat.com/jboss-set/zeus-vars/-/merge_requests/82