### PR TITLE
[SET-651] Enable vault role in playbooks

### DIFF
--- a/cci_run.yml
+++ b/cci_run.yml
@@ -4,7 +4,18 @@
   gather_facts: false
 
   vars_files:
+    - vars/vault.yml
     - vars/cci_automate.yml
+
+  pre_tasks:
+    - name: "Install hvac python library"
+      ansible.builtin.pip:
+        name: hvac>=1.2.1
+        executable: pip3
+
+    - name: "Load Secrets from Vault"
+      ansible.builtin.include_role:
+        name: "vault"
 
   tasks:
     - name: Automate CCI VM using Ansible

--- a/cci_worker.yml
+++ b/cci_worker.yml
@@ -5,10 +5,20 @@
   become: yes
 
   vars_files:
+    - vars/vault.yml
     - vars/cci.yml
     - vars/java.yml
 
   pre_tasks:
+    - name: "Install hvac python library"
+      ansible.builtin.pip:
+        name: hvac>=1.2.1
+        executable: pip3
+
+    - name: "Load Secrets from Vault"
+      ansible.builtin.include_role:
+        name: "vault"
+
     - name: Register
       redhat_subscription:
         state: present

--- a/jenkins.yml
+++ b/jenkins.yml
@@ -4,6 +4,7 @@
   become: yes
   become_user: root
   vars_files:
+    - vars/vault.yml
     - vars/olympus.yml
     - vars/component-alignment.yml
     - vars/aphrodite.yml
@@ -11,6 +12,15 @@
     - vars/mailer.yml
 
   pre_tasks:
+    - name: "Install hvac python library"
+      ansible.builtin.pip:
+        name: hvac>=1.2.1
+        executable: pip3
+
+    - name: "Load Secrets from Vault"
+      ansible.builtin.include_role:
+        name: "vault"
+
     - name: Register
       redhat_subscription:
         state: present

--- a/zeus.yml
+++ b/zeus.yml
@@ -4,6 +4,7 @@
   become: yes
   become_user: root
   vars_files:
+      - vars/vault.yml
       - vars/ansible.yml
       - vars/olympus.yml
       - vars/ssh.yml
@@ -23,6 +24,15 @@
       - vars/qualys.yml
 
   pre_tasks:
+    - name: "Install hvac python library"
+      ansible.builtin.pip:
+        name: hvac>=1.2.1
+        executable: pip3
+
+    - name: "Load Secrets from Vault"
+      ansible.builtin.include_role:
+        name: "vault"
+
     - name: Register
       community.general.redhat_subscription:
         state: present


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/SET-651

This is a follow up PR of https://github.com/jboss-set/zeus/pull/232.

This PR tries to enable `vault` role in the playbooks which may need access credential information.

* It makes sure the `hvac` python library installed according to the requirement from the [community.hashi_vault ansible collection](https://docs.ansible.com/ansible/latest/collections/community/hashi_vault/docsite/user_guide.html#ansible-collections-community-hashi-vault-docsite-user-guide-requirements). 
* It assumes the vault related configurations are in `vars/vault.yml` file
* It has the `vault` role as the first task in the `pre_tasks` section to prepare needed sensitive values before other tasks.