### PR TITLE
CCI worker settings.xml: add profile with product repositories

### DIFF
--- a/roles/cci_worker/templates/settings.xml.j2
+++ b/roles/cci_worker/templates/settings.xml.j2
@@ -25,14 +25,78 @@ under the License.
   <proxies/>
   <servers/>
   <mirrors>
-{% for mvn_cache in cci_worker.maven.caches %}
+    {% for mvn_cache in cci_worker.maven.caches %}
     <mirror>
       <id>{{ mvn_cache.name }}</id>
       <mirrorOf>{{ mvn_cache.mirrorOf }}</mirrorOf>
       <name>{{ mvn_cache.desc }}</name>
       <url>{{ mvn_cache.url }}</url>
     </mirror>
-{% endfor %}
+    {% endfor %}
   </mirrors>
-  <profiles/>
+  <profiles>
+    <profile>
+      <id>product-repositories</id>
+      <repositories>
+        <repository>
+          <id>jboss-eap-8.0-product-repository</id>
+          <name>JBoss EAP Product Repository</name>
+          <url>https://download.devel.redhat.com/brewroot/repos/jb-eap-8.0-maven-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>jboss-enterprise-maven-repository</id>
+          <name>JBoss Enterprise Maven Repository</name>
+          <url>https://maven.repository.redhat.com/ga/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-eap-8.0-product-repository</id>
+          <name>JBoss EAP Product Repository</name>
+          <url>https://download.devel.redhat.com/brewroot/repos/jb-eap-8.0-maven-build/latest/maven/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>jboss-enterprise-maven-repository</id>
+          <name>JBoss Enterprise Maven Repository</name>
+          <url>https://maven.repository.redhat.com/ga/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
 </settings>


### PR DESCRIPTION
This helps with building productized projects that need access to Brew & MRRC, but don't have those repos configured in their pom.xml.